### PR TITLE
SMPT settings to variables for configs support

### DIFF
--- a/blocks/send-email.json
+++ b/blocks/send-email.json
@@ -1,5 +1,5 @@
 {
   "dependencies": ["lodash"],
-  "functions": ["sendEmail 2.2"],
+  "functions": ["sendEmail 2.3"],
   "includes": ["./functions/utils"]
 }

--- a/functions/send-email/2.3/function.json
+++ b/functions/send-email/2.3/function.json
@@ -10,7 +10,7 @@
     {
       "meta": {
         "type": "Value",
-        "allowedKinds": ["STRING", "INTEGER"],
+        "allowedKinds": ["STRING"],
         "validations": { "required": true }
       },
       "name": "host",
@@ -24,7 +24,7 @@
     {
       "meta": {
         "type": "Value",
-        "allowedKinds": ["STRING"],
+        "allowedKinds": ["STRING", "INTEGER"],
         "validations": { "required": true }
       },
       "name": "port",

--- a/functions/send-email/2.3/function.json
+++ b/functions/send-email/2.3/function.json
@@ -1,0 +1,211 @@
+{
+  "description": "Send an e-mail using SMTP credentials v2.3",
+  "label": "Send Email",
+  "category": "External",
+  "icon": {
+    "color": "Orange",
+    "name": "AtIcon"
+  },
+  "options": [
+    {
+      "meta": {
+        "type": "Value",
+        "allowedKinds": ["STRING", "INTEGER"],
+        "validations": { "required": true }
+      },
+      "name": "host",
+      "label": "Hostname",
+      "info": "The hostname of the SMTP server you want to use",
+      "advanced": false,
+      "configuration": {
+        "placeholder": "smtp.flowmailer.net"
+      }
+    },
+    {
+      "meta": {
+        "type": "Value",
+        "allowedKinds": ["STRING"],
+        "validations": { "required": true }
+      },
+      "name": "port",
+      "label": "Port",
+      "info": "The port number of the SMTP server you want to use",
+      "advanced": false,
+      "configuration": {
+        "placeholder": "587"
+      }
+    },
+    {
+      "meta": {
+        "type": "Value",
+        "allowedKinds": ["STRING"],
+        "validations": { "required": true }
+      },
+      "name": "username",
+      "label": "Username",
+      "info": "The username of the SMTP server you want to use",
+      "advanced": false,
+      "configuration": {
+        "placeholder": ""
+      }
+    },
+    {
+      "meta": {
+        "type": "Value",
+        "allowedKinds": ["STRING"],
+        "validations": { "required": true }
+      },
+      "name": "password",
+      "label": "Password",
+      "info": "The password of the SMTP server you want to use",
+      "advanced": false,
+      "configuration": {
+        "placeholder": "******"
+      }
+    },
+    {
+      "meta": {
+        "type": "Boolean"
+      },
+      "name": "secure",
+      "label": "Secure?",
+      "info": "if true the connection will use TLS when connecting to server. If false (the default) then TLS is used if server supports the STARTTLS extension. In most cases set this value to true if you are connecting to port 465. For port 587 or 25 keep it false",
+      "advanced": false
+    },
+    {
+      "meta": {
+        "type": "Text",
+        "validations": { "required": true }
+      },
+      "name": "senderEmail",
+      "label": "Sender E-mail",
+      "info": "The email address of the sender",
+      "advanced": false
+    },
+    {
+      "meta": {
+        "type": "Text"
+      },
+      "name": "senderName",
+      "label": "Sender Name",
+      "info": "The display name of the sender",
+      "advanced": false
+    },
+    {
+      "meta": {
+        "type": "Text",
+        "validations": { "required": true }
+      },
+      "name": "toEmail",
+      "label": "Recipient",
+      "info": "The email address of the recipient",
+      "advanced": false
+    },
+    {
+      "meta": {
+        "type": "Text"
+      },
+      "name": "toName",
+      "label": "Recipient name",
+      "info": "The name of the recipient",
+      "advanced": false
+    },
+    {
+      "meta": {
+        "type": "Text"
+      },
+      "name": "cc",
+      "label": "CC",
+      "info": "The email address of the CC",
+      "advanced": false
+    },
+    {
+      "meta": {
+        "type": "Text"
+      },
+      "name": "replyTo",
+      "label": "Reply To",
+      "info": "The email address for the reply to if you want to differentiate it from the sender email address",
+      "advanced": false
+    },
+    {
+      "meta": {
+        "type": "Text"
+      },
+      "name": "bcc",
+      "label": "BCC",
+      "info": "The email address of the BCC",
+      "advanced": false
+    },
+    {
+      "meta": {
+        "type": "Text"
+      },
+      "name": "subject",
+      "label": "Subject",
+      "info": "The subject of the email",
+      "advanced": false
+    },
+    {
+      "meta": {
+        "type": "MultilineText"
+      },
+      "name": "body",
+      "label": "Body Template",
+      "info": "The HTML body of the email with LiquidJS support",
+      "advanced": false,
+      "configuration": {
+        "placeholder": "This field supports HTML, CSS and LiquidJS for easy templating"
+      }
+    },
+    {
+      "info": "Select all the variables you want to have available in the template with a key",
+      "label": "Template Variables",
+      "meta": {
+        "type": "Map"
+      },
+      "name": "variables"
+    },
+    {
+      "info": "Select the attachments you want to send with this email. Specify the filename in the left column, the file url in the right",
+      "label": "Attachments",
+      "meta": {
+        "type": "Map"
+      },
+      "name": "attachments"
+    },
+    {
+      "info": "Select the collection of attachments you want to send with this email.",
+      "label": "Attachments (collection)",
+      "meta": {
+        "type": "Collection"
+      },
+      "name": "attachmentsCol"
+    },
+    {
+      "info": "Select the property which contains the file in the collection",
+      "label": "Property",
+      "meta": {
+        "type": "Property",
+        "model": "attachmentsCol",
+        "allowedKinds": ["FILE"]
+      },
+      "configuration": {
+        "dependsOn": ["attachmentsCol"]
+      },
+      "name": "attachmentsColProperty"
+    },
+    {
+      "meta": {
+        "type": "Output",
+        "output": {
+          "type": "JSON"
+        }
+      },
+      "name": "result",
+      "label": "As",
+      "info": "The result"
+    }
+  ],
+  "yields": "NONE"
+}

--- a/functions/send-email/2.3/index.js
+++ b/functions/send-email/2.3/index.js
@@ -1,0 +1,103 @@
+import _ from "lodash";
+import Liquid from "../../utils/liquid.min";
+
+const mapAttachments = (attachmentsMap, attachmentsCol, attachmentProp) => {
+  const attachments = [];
+  attachmentsMap.map(({ key, value }) => {
+    if (!value) return;
+    if (!key) return;
+    attachments.push({
+      filename: key,
+      path: value && value.url ? value.url : value,
+    });
+  });
+
+  if (attachmentsCol && attachmentsCol.data) {
+    const prop = attachmentProp[0].name;
+    attachmentsCol.data.map((item) => {
+      const fileName = item[prop].name;
+      const fileUrl =
+        item[prop].url && item[prop].url ? item[prop].url : item[prop];
+      attachments.push({ filename: fileName, path: fileUrl });
+    });
+  }
+
+  return attachments;
+};
+
+const sendEmail = async ({
+  host,
+  port,
+  username,
+  password,
+  secure,
+  senderEmail,
+  senderName,
+  toEmail,
+  toName,
+  cc,
+  bcc,
+  subject,
+  body,
+  variables,
+  attachments,
+  attachmentsCol,
+  attachmentsColProperty,
+  replyTo,
+}) => {
+  if (!host || !port || !username || !password || !senderEmail || !toEmail) {
+    throw new Error(
+      "Not all required e-mail parameters are filled in. Please check your SMTP settings and try again."
+    );
+  }
+  const smtpCredentials = {
+    host,
+    port,
+    username,
+    password,
+    secure,
+  };
+
+  const engine = new Liquid();
+  engine.registerFilter("group", (collection, key) =>
+    _.groupBy(collection, key)
+  );
+
+  const renderedBody = engine.parseAndRenderSync(
+    body,
+    variables.reduce((ctx, { key, value }) => {
+      ctx[key] = value;
+      return ctx;
+    }, {})
+  );
+
+  const mappedAttachments = mapAttachments(
+    attachments,
+    attachmentsCol,
+    attachmentsColProperty
+  );
+
+  const mail = {
+    sender: {
+      from: senderName ? `"${senderName}" ${senderEmail}` : senderEmail,
+      name: senderName,
+      replyTo,
+    },
+    recipient: {
+      to: toName ? `"${toName}" ${toEmail}` : toEmail,
+      cc: cc,
+      bcc: bcc,
+    },
+    subject,
+    body: renderedBody,
+    attachments: mappedAttachments,
+  };
+
+  const sentMail = await smtp(smtpCredentials, mail);
+
+  return {
+    result: sentMail,
+  };
+};
+
+export default sendEmail;


### PR DESCRIPTION
Added validations in function.json and code
Removed redundant liquid.min.js
---
Turned SMTP settings into VALUE types to better support the use of BB configurations (where PORT is saved as a text)
Didn't need any parsing to number in the code for it to work. 
Made the SMTP options and SenderEmail and ToEmail required in functions.json and added a validation line in the code for when the configs are not filled in. In de email folder was a second liquid.min.js while it was being loaded from /../../utils/liquid.min.js so removed the other one.